### PR TITLE
fix interpolation ranges on Android

### DIFF
--- a/src/SpriteSheet.js
+++ b/src/SpriteSheet.js
@@ -120,7 +120,7 @@ export default class SpriteSheet extends React.PureComponent {
 
     for (let key in animations) {
       let { length } = animations[key];
-      let input = [].concat(...Array.from({ length: length  }, (_, i) => [i, i + 0.99999999999]));
+      let input = [].concat(...Array.from({ length }, (_, i) => [i, i + 0.99999999999]));
 
       this.interpolationRanges[key] = {
         top: {

--- a/src/SpriteSheet.js
+++ b/src/SpriteSheet.js
@@ -120,7 +120,7 @@ export default class SpriteSheet extends React.PureComponent {
 
     for (let key in animations) {
       let { length } = animations[key];
-      let input = [].concat(...Array.from(Array(length).keys()).map(i => [i, i + 0.99999999999]));
+      let input = [].concat(...Array.from({ length: length  }, (_, i) => [i, i + 0.99999999999]));
 
       this.interpolationRanges[key] = {
         top: {


### PR DESCRIPTION
This line was causing the following error on Android:

```
Invariant Violation: inputRange must have at least 2 elements
```

After this change, the error is gone.