### PR TITLE
Added reset function to SpriteSheet.js

### DIFF
--- a/src/SpriteSheet.js
+++ b/src/SpriteSheet.js
@@ -166,6 +166,11 @@ export default class SpriteSheet extends React.PureComponent {
     this.time.stopAnimation(cb);
   };
 
+  reset = () => {
+    this.time.stopAnimation();
+    this.time.setValue(0);
+  };
+
   play = ({
     type,
     fps = 24,


### PR DESCRIPTION
Thought it was a good idea to include a function to stop and reset sprite sheet to frame 0, other implementations are welcome as I just went for the simplest I could think of.

Attempted to use built in Animated.Value.resetAnimation() function, didn't seem to work properly.