### PR TITLE
Adds optional props offsetX offsetY frameHeight and frameWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ A sprite sheet animation library for React Native
   rows={6}
   // height={200} // set either, none, but not both
   // width={200}
+
+  // frameHeight={50} // manually set size of your sprite
+  // frameWidth={50} // overrides auto calculation of frame size based on height, width, columns, and rows.
+  // offsetX={0} 
+  // offsetY={0} 
   imageStyle={{ marginTop: -1 }}
   animations={{
     walk: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
@@ -71,7 +76,11 @@ static propTypes = {
   imageStyle: stylePropType, // styles for the sprite sheet
   height: PropTypes.number, // set either height, width, or none,
   width: PropTypes.number, // but not both height and width
-  onLoad: PropTypes.func
+  onLoad: PropTypes.func,
+  frameWidth: PropTypes.func, // overrides sprite size calculation based on height,width,rows,columns props
+  frameHeight: PropTypes.func, // both frameWidth and frameHeight must be set or neither
+  offsetX: PropTypes.func, // used with frameWidth/frameHeight to adjust offset of first frame
+  offsetY: PropTypes.func
 };
 
 static defaultPropTypes = {

--- a/src/SpriteSheet.js
+++ b/src/SpriteSheet.js
@@ -1,6 +1,4 @@
 import { Animated, Easing, View } from "react-native";
-import Svg,{Image}from 'react-native-svg';
-
 import PropTypes from "prop-types";
 import React from "react";
 import resolveAssetSource from "react-native/Libraries/Image/resolveAssetSource";

--- a/src/SpriteSheet.js
+++ b/src/SpriteSheet.js
@@ -102,8 +102,6 @@ export default class SpriteSheet extends React.PureComponent {
     let { viewStyle, imageStyle, source, onLoad } = this.props;
 
     let {
-      // translateY = { in: [0,0], out: [0,0] },
-      // translateX = { in: [0,0], out: [0,0] }
       translateY = { in: [0,0], out: [offsetY, offsetY] },
       translateX = { in: [0,0], out: [offsetX, offsetX] }
     } = this.interpolationRanges[animationType] || {};

--- a/src/SpriteSheet.js
+++ b/src/SpriteSheet.js
@@ -1,4 +1,5 @@
 import { Animated, Easing, View } from "react-native";
+import Svg,{Image}from 'react-native-svg';
 
 import PropTypes from "prop-types";
 import React from "react";
@@ -25,7 +26,9 @@ export default class SpriteSheet extends React.PureComponent {
     imageStyle: stylePropType, // styles for the sprite sheet
     height: PropTypes.number, // set either height, width, or neither
     width: PropTypes.number, // do not set both height and width
-    onLoad: PropTypes.func
+    onLoad: PropTypes.func,
+    frameWidth: PropTypes.number,
+    frameHeight: PropTypes.number,
   };
 
   static defaultPropTypes = {
@@ -50,13 +53,15 @@ export default class SpriteSheet extends React.PureComponent {
     this.time = new Animated.Value(0);
     this.interpolationRanges = {};
 
-    let { source, height, width, rows, columns } = this.props;
+    let { source, height, width, rows, columns, frameHeight, frameWidth, offsetY = 0, offsetX = 0 } = this.props;
     let image = resolveAssetSource(source);
     let ratio = 1;
     let imageHeight = image.height;
     let imageWidth = image.width;
-    let frameHeight = image.height / rows;
-    let frameWidth = image.width / columns;
+    offsetX = -offsetX;
+    offsetY = -offsetY;
+    frameHeight = frameHeight || image.height / rows;
+    frameWidth = frameWidth || image.width / columns;
 
     if (width) {
       ratio = (width * columns) / image.width;
@@ -76,7 +81,9 @@ export default class SpriteSheet extends React.PureComponent {
       imageHeight,
       imageWidth,
       frameHeight,
-      frameWidth
+      frameWidth,
+      offsetX,
+      offsetY
     });
 
     this.generateInterpolationRanges();
@@ -88,13 +95,17 @@ export default class SpriteSheet extends React.PureComponent {
       imageWidth,
       frameHeight,
       frameWidth,
-      animationType
+      animationType,
+      offsetX,
+      offsetY
     } = this.state;
     let { viewStyle, imageStyle, source, onLoad } = this.props;
 
     let {
-      translateY = { in: [0, 0], out: [0, 0] },
-      translateX = { in: [0, 0], out: [0, 0] }
+      // translateY = { in: [0,0], out: [0,0] },
+      // translateX = { in: [0,0], out: [0,0] }
+      translateY = { in: [0,0], out: [offsetY, offsetY] },
+      translateX = { in: [0,0], out: [offsetX, offsetX] }
     } = this.interpolationRanges[animationType] || {};
 
     return (
@@ -210,11 +221,13 @@ export default class SpriteSheet extends React.PureComponent {
   };
 
   getFrameCoords = i => {
-    let { columns } = this.props;
+    let { columns, offsetX, offsetY } = this.props;
     let { frameHeight, frameWidth } = this.state;
     let currentColumn = i % columns;
     let xAdjust = -currentColumn * frameWidth;
-    let yAdjust = -((i - currentColumn) / columns) * frameHeight;
+    xAdjust -= offsetX;
+    let yAdjust = -((i - currentColumn) / columns) * frameHeight ;
+    yAdjust -= offsetY;
 
     return {
       x: xAdjust,


### PR DESCRIPTION
For my use case I had a spritesheet with multiple sprite animation and sizes. I didn't want to manually crop the sprites so I just resorted to adding these optional params which allowed me to define the shape of the sprites and where the frames should start from. 
