### PR TITLE
Fix default props typo

### DIFF
--- a/src/SpriteSheet.js
+++ b/src/SpriteSheet.js
@@ -22,7 +22,7 @@ export default class SpriteSheet extends React.PureComponent {
     frameHeight: PropTypes.number,
   };
 
-  static defaultPropTypes = {
+  static defaultProps = {
     columns: 1,
     rows: 1,
     animations: {},


### PR DESCRIPTION
The default property setter was misnamed, so the defaults were not being applied. It should be defaultProps.

Fixes https://github.com/MiLeung/rn-sprite-sheet/issues/27